### PR TITLE
Fixed a potential 0xcccccccc violation access error when solClient_se…

### DIFF
--- a/src/HelloWorldPubSub/HelloWorldPub.c
+++ b/src/HelloWorldPubSub/HelloWorldPub.c
@@ -61,7 +61,7 @@ main ( int argc, char *argv[] )
     solClient_session_createFuncInfo_t sessionFuncInfo = SOLCLIENT_SESSION_CREATEFUNC_INITIALIZER;
 
     /* Session Properties */
-    const char     *sessionProps[50];
+    const char     *sessionProps[50] = {0,};
     int             propIndex = 0;
     char *username,*password,*vpnname,*host;
 

--- a/src/HelloWorldPubSub/HelloWorldSub.c
+++ b/src/HelloWorldPubSub/HelloWorldSub.c
@@ -72,7 +72,7 @@ main ( int argc, char *argv[] )
     solClient_session_createFuncInfo_t sessionFuncInfo = SOLCLIENT_SESSION_CREATEFUNC_INITIALIZER;
 
     /* Session Properties */
-    const char     *sessionProps[50];
+    const char     *sessionProps[50] = {0,};
     int             propIndex = 0;
     char *username,*password,*vpnname,*host;
 


### PR DESCRIPTION
This issue was encountered by a customer who create raised a support ticket (ID 32329). 

Basically, the array of sessionProps should be initialized to 0 to potentially avoid this issue.