### PR TITLE
setenv.sh is not a script

### DIFF
--- a/build/intro/linux/x64/setenv.sh
+++ b/build/intro/linux/x64/setenv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+
 
 script_dir="$(dirname -- "$(readlink -f -- "$0")")"
 export LD_LIBRARY_PATH=$script_dir

--- a/build/intro/linux/x86/setenv.sh
+++ b/build/intro/linux/x86/setenv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+
 
 script_dir="$(dirname -- "$(readlink -f -- "$0")")"
 export LD_LIBRARY_PATH=$script_dir


### PR DESCRIPTION
Having a shebang line in these files is a bit misleading as:
- there is a shebang line, implying it is a script
- the file is executable, implying it is a script
but it should not run as a subprocess, because once the subprocess ends, the newly set environment variable disappears along with the subprocess.